### PR TITLE
Various small fixes

### DIFF
--- a/emacsql-compiler.el
+++ b/emacsql-compiler.el
@@ -161,7 +161,7 @@
   "Cache used to memoize `emacsql-prepare'.")
 
 (defvar emacsql--vars ()
-  "For use with `emacsql-with-vars'.")
+  "For use with `emacsql-with-params'.")
 
 (defun emacsql-sql-p (thing)
   "Return non-nil if THING looks like a prepared statement."
@@ -293,7 +293,7 @@ which will be combined with variable definitions."
     (mapconcat #'expr idents ", ")))
 
 (defun emacsql--*combine (prepared)
-  "Only use within `emacsql-with-vars'!"
+  "Only use within `emacsql-with-params'!"
   (cl-destructuring-bind (string . vars) prepared
     (setf emacsql--vars (nconc emacsql--vars vars))
     string))

--- a/emacsql-compiler.el
+++ b/emacsql-compiler.el
@@ -88,15 +88,9 @@
     (vector (concat "(" (mapconcat #'emacsql-escape-scalar vector ", ") ")"))
     (otherwise (emacsql-error "Invalid vector %S" vector))))
 
-(defun emacsql-escape-format (thing &optional kind)
-  "Escape THING for use as a `format' spec, pre-escaping for KIND.
-KIND should be :scalar or :identifier."
-  (replace-regexp-in-string
-   "%" "%%" (cl-case kind
-              (:scalar (emacsql-escape-scalar thing))
-              (:identifier (emacsql-escape-identifier thing))
-              (:vector (emacsql-escape-vector thing))
-              (otherwise thing))))
+(defun emacsql-escape-format (thing)
+  "Escape THING for use as a `format' spec."
+  (replace-regexp-in-string "%" "%%" thing))
 
 ;;; Schema compiler
 

--- a/emacsql-compiler.el
+++ b/emacsql-compiler.el
@@ -161,7 +161,7 @@
   "Cache used to memoize `emacsql-prepare'.")
 
 (defvar emacsql--vars ()
-  "For use with `emacsql-with-params'.")
+  "Used within `emacsql-with-params' to collect parameters.")
 
 (defun emacsql-sql-p (thing)
   "Return non-nil if THING looks like a prepared statement."
@@ -200,7 +200,9 @@ which will be combined with variable definitions."
        (cons (concat ,prefix (progn ,@body)) emacsql--vars))))
 
 (defun emacsql--!param (thing &optional kind)
-  "Only use within `emacsql-with-params'!"
+  "Parse, escape, and store THING.
+If optional KIND is not specified, then try to guess it.
+Only use within `emacsql-with-params'!"
   (cl-flet ((check (param)
                    (when (and kind (not (eq kind (cdr param))))
                      (emacsql-error
@@ -293,7 +295,8 @@ which will be combined with variable definitions."
     (mapconcat #'expr idents ", ")))
 
 (defun emacsql--*combine (prepared)
-  "Only use within `emacsql-with-params'!"
+  "Append parameters from PREPARED to `emacsql--vars', return the string.
+Only use within `emacsql-with-params'!"
   (cl-destructuring-bind (string . vars) prepared
     (setf emacsql--vars (nconc emacsql--vars vars))
     string))

--- a/emacsql-compiler.el
+++ b/emacsql-compiler.el
@@ -183,7 +183,7 @@ vector (v), schema (S)."
                 (?S :schema)))))))
 
 (defmacro emacsql-with-params (prefix &rest body)
-  "Evaluate BODY, collecting patameters.
+  "Evaluate BODY, collecting parameters.
 Provided local functions: `param', `identifier', `scalar',
 `svector', `expr', `subsql', and `combine'. BODY should return a string,
 which will be combined with variable definitions."


### PR DESCRIPTION
While reading the source in order to tackle #7 I ran into some small issues which this pr fixes.

I also have a few small questions:

* What's the `(if (string-match-p ":" name)` branch in `emacsql-escape-identifier` for?

* While making changes to the compiler it would be nice if it were possible to easily turn of the `emacsql-prepare-cache` by setting it to `nil` which would require a small change to `emacsql-prepare`. I know I could just use `emacsql-prepare--sexp` and `emacsql-format` directly to bypass the cache, but I would also like to use my existing application for testing. Would you accept a patch which does this?