### PR TITLE
Save match-data around call to accept-process-output

### DIFF
--- a/emacsql.el
+++ b/emacsql.el
@@ -156,7 +156,8 @@ MESSAGE should not have a newline on the end."
          (end (when real-timeout (+ (float-time) real-timeout))))
     (while (and (or (null real-timeout) (< (float-time) end))
                 (not (emacsql-waiting-p connection)))
-      (accept-process-output (emacsql-process connection) real-timeout))
+      (save-match-data
+        (accept-process-output (emacsql-process connection) real-timeout)))
     (unless (emacsql-waiting-p connection)
       (signal 'emacsql-timeout (list "Query timed out" real-timeout)))))
 


### PR DESCRIPTION
Unfortunately `accept-process-output` messes with the match-data. Figuring out why `oset`, when advised by [`closql`](https://gitlab.com/tarsius/closql), which transparently stores objects in an EmacSQL SQLite database and which I use in [`epkg`](https://gitlab.com/tarsius/epkg), did change match-data was quite a journey, and when I had figured out that somehow `oset` is responsible I was already half way through it... ;-)

Anyway, I would like to fix this as close to the source as possible and this is here. Please also create a new tag so that I can depend on a version which has this kludge.