### PR TITLE
Use cl-generic package

### DIFF
--- a/emacsql-mysql.el
+++ b/emacsql-mysql.el
@@ -5,7 +5,7 @@
 ;; Author: Christopher Wellons <wellons@nullprogram.com>
 ;; URL: https://github.com/skeeto/emacsql
 ;; Version: 1.0.0
-;; Package-Requires: ((emacs "24.3") (cl-lib "0.3") (emacsql "2.0.0"))
+;; Package-Requires: ((emacs "24.3") (cl-generic "0.3") (cl-lib "0.3") (emacsql "2.0.0"))
 
 ;;; Commentary:
 
@@ -14,6 +14,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'cl-generic)
 (require 'eieio)
 (require 'emacsql)
 
@@ -92,24 +93,24 @@ http://dev.mysql.com/doc/refman/5.5/en/reserved-words.html")
                [:set-transaction-isolation-level :serializable])
       (emacsql-register connection))))
 
-(defmethod emacsql-close ((connection emacsql-mysql-connection))
+(cl-defmethod emacsql-close ((connection emacsql-mysql-connection))
   (let ((process (emacsql-process connection)))
     (when (process-live-p process)
       (process-send-eof process))))
 
-(defmethod emacsql-send-message ((connection emacsql-mysql-connection) message)
+(cl-defmethod emacsql-send-message ((connection emacsql-mysql-connection) message)
   (let ((process (emacsql-process connection)))
     (process-send-string process message)
     (process-send-string process "\\c\\p\n")))
 
-(defmethod emacsql-waiting-p ((connection emacsql-mysql-connection))
+(cl-defmethod emacsql-waiting-p ((connection emacsql-mysql-connection))
   (let ((length (length emacsql-mysql-sentinel)))
     (with-current-buffer (emacsql-buffer connection)
       (and (>= (buffer-size) length)
            (progn (setf (point) (- (point-max) length))
                   (looking-at emacsql-mysql-sentinel))))))
 
-(defmethod emacsql-parse ((connection emacsql-mysql-connection))
+(cl-defmethod emacsql-parse ((connection emacsql-mysql-connection))
   (with-current-buffer (emacsql-buffer connection)
     (let ((standard-input (current-buffer)))
       (setf (point) (point-min))

--- a/emacsql-pg.el
+++ b/emacsql-pg.el
@@ -18,6 +18,7 @@
 (require 'pg)
 (require 'eieio)
 (require 'cl-lib)
+(require 'cl-generic)
 (require 'emacsql)
 (require 'emacsql-psql)  ; for reserved words
 
@@ -45,20 +46,20 @@
     (emacsql connection [:set (= default-transaction-isolation 'SERIALIZABLE)])
     (emacsql-register connection)))
 
-(defmethod emacsql-close ((connection emacsql-pg-connection))
+(cl-defmethod emacsql-close ((connection emacsql-pg-connection))
   (ignore-errors (pg:disconnect (emacsql-pg-pgcon connection))))
 
-(defmethod emacsql-send-message ((connection emacsql-pg-connection) message)
+(cl-defmethod emacsql-send-message ((connection emacsql-pg-connection) message)
   (condition-case error
       (setf (emacsql-pg-result connection)
             (pg:exec (emacsql-pg-pgcon connection) message))
     (error (signal 'emacsql-error error))))
 
-(defmethod emacsql-waiting-p ((_connection emacsql-pg-connection))
+(cl-defmethod emacsql-waiting-p ((_connection emacsql-pg-connection))
   ;; pg:exec will block
   t)
 
-(defmethod emacsql-parse ((connection emacsql-pg-connection))
+(cl-defmethod emacsql-parse ((connection emacsql-pg-connection))
   (let ((tuples (pg:result (emacsql-pg-result connection) :tuples)))
     (cl-loop for tuple in tuples collect
              (cl-loop for value in tuple

--- a/emacsql-psql.el
+++ b/emacsql-psql.el
@@ -5,7 +5,7 @@
 ;; Author: Christopher Wellons <wellons@nullprogram.com>
 ;; URL: https://github.com/skeeto/emacsql
 ;; Version: 1.0.0
-;; Package-Requires: ((emacs "24.3") (cl-lib "0.3") (emacsql "2.0.0") (pg "0.12"))
+;; Package-Requires: ((emacs "24.3") (cl-generic "0.3") (cl-lib "0.3") (emacsql "2.0.0") (pg "0.12"))
 
 ;;; Commentary:
 
@@ -17,6 +17,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'cl-generic)
 (require 'eieio)
 (require 'emacsql)
 
@@ -103,24 +104,24 @@ http://www.postgresql.org/docs/7.3/static/sql-keywords-appendix.html")
                [:set (= default-transaction-isolation 'SERIALIZABLE)])
       (emacsql-register connection))))
 
-(defmethod emacsql-close ((connection emacsql-psql-connection))
+(cl-defmethod emacsql-close ((connection emacsql-psql-connection))
   (let ((process (emacsql-process connection)))
     (when (process-live-p process)
       (process-send-string process "\\q\n"))))
 
-(defmethod emacsql-send-message ((connection emacsql-psql-connection) message)
+(cl-defmethod emacsql-send-message ((connection emacsql-psql-connection) message)
   (let ((process (emacsql-process connection)))
     (process-send-string process message)
     (process-send-string process "\n")))
 
-(defmethod emacsql-waiting-p ((connection emacsql-psql-connection))
+(cl-defmethod emacsql-waiting-p ((connection emacsql-psql-connection))
   (with-current-buffer (emacsql-buffer connection)
     (cond ((= (buffer-size) 1) (string= "]" (buffer-string)))
           ((> (buffer-size) 1) (string= "\n]"
                                         (buffer-substring
                                          (- (point-max) 2) (point-max)))))))
 
-(defmethod emacsql-check-error ((connection emacsql-psql-connection))
+(cl-defmethod emacsql-check-error ((connection emacsql-psql-connection))
   (with-current-buffer (emacsql-buffer connection)
     (let ((case-fold-search t))
       (setf (point) (point-min))
@@ -129,7 +130,7 @@ http://www.postgresql.org/docs/7.3/static/sql-keywords-appendix.html")
                (end (line-end-position)))
           (signal 'emacsql-error (list (buffer-substring beg end))))))))
 
-(defmethod emacsql-parse ((connection emacsql-psql-connection))
+(cl-defmethod emacsql-parse ((connection emacsql-psql-connection))
   (emacsql-check-error connection)
   (with-current-buffer (emacsql-buffer connection)
     (let ((standard-input (current-buffer)))

--- a/emacsql-sqlite.el
+++ b/emacsql-sqlite.el
@@ -5,7 +5,7 @@
 ;; Author: Christopher Wellons <wellons@nullprogram.com>
 ;; URL: https://github.com/skeeto/emacsql
 ;; Version: 1.0.0
-;; Package-Requires: ((emacs "24.3") (cl-lib "0.3") (emacsql "2.0.0"))
+;; Package-Requires: ((emacs "24.3") (cl-generic "0.3") (cl-lib "0.3") (emacsql "2.0.0"))
 
 ;;; Commentary:
 
@@ -18,6 +18,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'cl-generic)
 (require 'eieio)
 (require 'url)
 (require 'url-http)
@@ -88,7 +89,7 @@ http://www.sqlite.org/lang_keywords.html")
                       (nil nil))))
   (:documentation "A connection to a SQLite database."))
 
-(defmethod initialize-instance :after
+(cl-defmethod initialize-instance :after
   ((connection emacsql-sqlite-connection) &key)
   (emacsql-sqlite-ensure-binary)
   (let* ((process-connection-type nil)  ; use a pipe
@@ -118,13 +119,13 @@ buffer. This is for debugging purposes."
       (emacsql-enable-debugging connection))
     connection))
 
-(defmethod emacsql-close ((connection emacsql-sqlite-connection))
+(cl-defmethod emacsql-close ((connection emacsql-sqlite-connection))
   "Gracefully exits the SQLite subprocess."
   (let ((process (emacsql-process connection)))
     (when (process-live-p process)
       (process-send-eof process))))
 
-(defmethod emacsql-send-message ((connection emacsql-sqlite-connection) message)
+(cl-defmethod emacsql-send-message ((connection emacsql-sqlite-connection) message)
   (let ((process (emacsql-process connection)))
     (process-send-string process (format "%d " (string-bytes message)))
     (process-send-string process message)
@@ -141,7 +142,7 @@ buffer. This is for debugging purposes."
     ((27 28)                      emacsql-warning))
   "List of regexp's mapping sqlite3 output to conditions.")
 
-(defmethod emacsql-handle ((_ emacsql-sqlite-connection) code message)
+(cl-defmethod emacsql-handle ((_ emacsql-sqlite-connection) code message)
   "Get condition for MESSAGE provided from SQLite."
   (signal
    (or (cl-second (cl-assoc code emacsql-sqlite-condition-alist :test #'memql))

--- a/emacsql.el
+++ b/emacsql.el
@@ -5,7 +5,7 @@
 ;; Author: Christopher Wellons <wellons@nullprogram.com>
 ;; URL: https://github.com/skeeto/emacsql
 ;; Version: 2.0.2
-;; Package-Requires: ((emacs "24.3") (cl-lib "0.3") (finalize "1.0.0"))
+;; Package-Requires: ((emacs "24.3") (cl-generic "0.3") (cl-lib "0.3") (finalize "1.0.0"))
 
 ;;; Commentary:
 
@@ -97,34 +97,34 @@ If nil, wait forever.")
   (:documentation "A connection to a SQL database.")
   :abstract t)
 
-(defgeneric emacsql-close (connection)
+(cl-defgeneric emacsql-close (connection)
   "Close CONNECTION and free all resources.")
 
-(defgeneric emacsql-reconnect (connection)
+(cl-defgeneric emacsql-reconnect (connection)
   "Re-establish CONNECTION with the same parameters.")
 
-(defmethod emacsql-live-p ((connection emacsql-connection))
+(cl-defmethod emacsql-live-p ((connection emacsql-connection))
   "Return non-nil if CONNECTION is still alive and ready."
   (not (null (process-live-p (emacsql-process connection)))))
 
-(defgeneric emacsql-types (connection)
+(cl-defgeneric emacsql-types (connection)
   "Return an alist mapping EmacSQL types to database types.
 This will mask `emacsql-type-map' during expression compilation.
 This alist should have four key symbols: integer, float, object,
 nil (default type). The values are strings to be inserted into a
 SQL expression.")
 
-(defmethod emacsql-buffer ((connection emacsql-connection))
+(cl-defmethod emacsql-buffer ((connection emacsql-connection))
   "Get process buffer for CONNECTION."
   (process-buffer (emacsql-process connection)))
 
-(defmethod emacsql-enable-debugging ((connection emacsql-connection))
+(cl-defmethod emacsql-enable-debugging ((connection emacsql-connection))
   "Enable debugging on CONNECTION."
   (unless (buffer-live-p (emacsql-log-buffer connection))
     (setf (emacsql-log-buffer connection)
           (generate-new-buffer " *emacsql-log*"))))
 
-(defmethod emacsql-log ((connection emacsql-connection) message)
+(cl-defmethod emacsql-log ((connection emacsql-connection) message)
   "Log MESSAGE into CONNECTION's log.
 MESSAGE should not have a newline on the end."
   (let ((log (emacsql-log-buffer connection)))
@@ -135,22 +135,22 @@ MESSAGE should not have a newline on the end."
 
 ;;; Sending and receiving
 
-(defgeneric emacsql-send-message ((connection emacsql-connection) message)
+(cl-defgeneric emacsql-send-message ((connection emacsql-connection) message)
   "Send MESSAGE to CONNECTION.")
 
-(defmethod emacsql-send-message :before
+(cl-defmethod emacsql-send-message :before
   ((connection emacsql-connection) message)
   (emacsql-log connection message))
 
-(defmethod emacsql-clear ((connection emacsql-connection))
+(cl-defmethod emacsql-clear ((connection emacsql-connection))
   "Clear the process buffer for CONNECTION-SPEC."
   (with-current-buffer (emacsql-buffer connection)
     (erase-buffer)))
 
-(defgeneric emacsql-waiting-p (connection)
+(cl-defgeneric emacsql-waiting-p (connection)
   "Return non-nil if CONNECTION is ready for more input.")
 
-(defmethod emacsql-wait ((connection emacsql-connection) &optional timeout)
+(cl-defmethod emacsql-wait ((connection emacsql-connection) &optional timeout)
   "Block until CONNECTION is waiting for further input."
   (let* ((real-timeout (or timeout emacsql-global-timeout))
          (end (when real-timeout (+ (float-time) real-timeout))))
@@ -161,7 +161,7 @@ MESSAGE should not have a newline on the end."
     (unless (emacsql-waiting-p connection)
       (signal 'emacsql-timeout (list "Query timed out" real-timeout)))))
 
-(defgeneric emacsql-parse (connection)
+(cl-defgeneric emacsql-parse (connection)
   "Return the results of parsing the latest output or signal an error.")
 
 (defun emacsql-compile (connection sql &rest args)
@@ -170,7 +170,7 @@ MESSAGE should not have a newline on the end."
          (emacsql-type-map (or mask emacsql-type-map)))
     (concat (apply #'emacsql-format (emacsql-prepare sql) args) ";")))
 
-(defmethod emacsql ((connection emacsql-connection) sql &rest args)
+(cl-defmethod emacsql ((connection emacsql-connection) sql &rest args)
   "Send SQL s-expression to CONNECTION and return the results."
   (let ((sql-string (apply #'emacsql-compile connection sql args)))
     (emacsql-clear connection)
@@ -190,19 +190,19 @@ exactly one row per line, fields separated by whitespace. NULL
 must display as \"nil\".")
   :abstract t)
 
-(defmethod emacsql-waiting-p ((connection emacsql-protocol-mixin))
+(cl-defmethod emacsql-waiting-p ((connection emacsql-protocol-mixin))
   "Return true if the end of the buffer has a properly-formatted prompt."
   (with-current-buffer (emacsql-buffer connection)
     (and (>= (buffer-size) 2)
          (string= "#\n" (buffer-substring (- (point-max) 2) (point-max))))))
 
-(defmethod emacsql-handle ((_ emacsql-protocol-mixin) code message)
+(cl-defmethod emacsql-handle ((_ emacsql-protocol-mixin) code message)
   "Signal a specific condition for CODE from CONNECTION.
 Subclasses should override this method in order to provide more
 specific error conditions."
   (signal 'emacsql-error (list code message)))
 
-(defmethod emacsql-parse ((connection emacsql-protocol-mixin))
+(cl-defmethod emacsql-parse ((connection emacsql-protocol-mixin))
   "Parse well-formed output into an s-expression."
   (with-current-buffer (emacsql-buffer connection)
     (setf (point) (point-min))


### PR DESCRIPTION
Depend on `cl-generic` and use `cl-defgeneric` and `cl-defmethod` that
it defines, instead of `defgeneric` and `defmethod` from the `eieio`
package.

`cl-generic` is part of Emacs since 25.1.  It defines the functions
`cl-defgeneric` and `cl-defmethod`, which replace the prefix-less
variants `defgeneric` and `defmethod`.

The latter two are now considered obsolete and to allow authors to
move away from them while maintaining support for older Emacsen, GNU
Elpa features a forward-port of the `cl-generic` package, similar to
what done in the past with `cl-lib`.