### PR TITLE
fix ldlibs for berkeley-unix systems

### DIFF
--- a/emacsql-sqlite.el
+++ b/emacsql-sqlite.el
@@ -169,7 +169,7 @@ If called with non-nil ASYNC the return value is meaningless."
          (files (mapcar (lambda (f) (expand-file-name f src))
                         '("sqlite3.c" "emacsql.c")))
          (cflags (list (format "-I%s" src) (format "-O%d" (or o-level 2))))
-         (ldlibs (if (eq system-type 'windows-nt) () (list "-ldl")))
+         (ldlibs (if (memq system-type '(windows-nt berkeley-unix)) () (list "-ldl")))
          (options (emacsql-sqlite-compile-switches))
          (output (list "-o" emacsql-sqlite-executable))
          (arguments (nconc cflags options files ldlibs output)))


### PR DESCRIPTION
Hi @skeeto 

I had to adapt emacsql-sqlite-compile for berkeley systems. I'm running Freebsd:

```
$ uname -m -r -s
FreeBSD 11.0-RELEASE-p12 amd64

ELISP> system-type
berkeley-unix
```

The "-ldl" flag is not needed, as dl calls are provided by the libc on BSD systems.

Best regards.