### PR TITLE
Remove trailing &key in method definition

### DIFF
--- a/emacsql-sqlite.el
+++ b/emacsql-sqlite.el
@@ -90,7 +90,7 @@ http://www.sqlite.org/lang_keywords.html")
   (:documentation "A connection to a SQLite database."))
 
 (cl-defmethod initialize-instance :after
-  ((connection emacsql-sqlite-connection) &key)
+  ((connection emacsql-sqlite-connection) &optional slots)
   (emacsql-sqlite-ensure-binary)
   (let* ((process-connection-type nil)  ; use a pipe
          (coding-system-for-write 'utf-8-auto)


### PR DESCRIPTION
It seems that a trailing `&key` is not accepted anymore in Emacs 26. Please double-check that the fix is the expected one, I'm not sure.