### PR TITLE
[POC] Add a new SQLite backend using the sqlite3-api module

### DIFF
--- a/emacsql-compiler.el
+++ b/emacsql-compiler.el
@@ -190,6 +190,7 @@ vector (v), raw string (r), schema (S)."
         (cons (1- (read (substring name 2)))
               (cl-ecase (aref name 1)
                 (?i :identifier)
+                (?V :id-vector)
                 (?s :scalar)
                 (?v :vector)
                 (?r :raw)
@@ -227,6 +228,7 @@ Only use within `emacsql-with-params'!"
            (if kind
                (cl-case kind
                  (:identifier (emacsql-escape-identifier thing))
+                 (:id-vector (emacsql-escape-vector thing))
                  (:scalar (emacsql-escape-scalar thing))
                  (:vector (emacsql-escape-vector thing))
                  (:raw (emacsql-escape-raw thing))
@@ -382,6 +384,7 @@ Only use within `emacsql-with-params'!"
                     (let ((thing (nth i args)))
                       (cl-case kind
                         (:identifier (emacsql-escape-identifier thing))
+                        (:id-vector (emacsql-escape-vector thing))
                         (:scalar (emacsql-escape-scalar thing))
                         (:vector (emacsql-escape-vector thing))
                         (:raw (emacsql-escape-raw thing))

--- a/emacsql-sqlite3.el
+++ b/emacsql-sqlite3.el
@@ -86,6 +86,7 @@
                        (let ((thing (nth i args)))
                          (cl-case kind
                            (:identifier (emacsql-escape-identifier thing))
+                           (:id-vector  (emacsql-escape-vector thing))
                            (:scalar     (push thing params) "?")
                            (:vector     (dolist (thing (cl-coerce thing 'list))
                                           (push thing params))

--- a/emacsql-sqlite3.el
+++ b/emacsql-sqlite3.el
@@ -1,0 +1,67 @@
+;;; emacsql-sqlite.el --- EmacSQL back-end for SQLite -*- lexical-binding: t; -*-
+
+;; This is free and unencumbered software released into the public domain.
+
+;; URL: https://github.com/skeeto/emacsql
+;; Package-Requires: ((emacs "25.1") (emacsql "2.0.0") (sqlite3-api "0.11"))
+
+;;; Code:
+
+(require 'cl-lib)
+(require 'cl-generic)
+(require 'eieio)
+(require 'url)
+(require 'url-http)
+(require 'emacsql)
+(require 'sqlite3-api)
+(require 'subr-x)
+
+(defclass emacsql-sqlite3-connection (emacsql-connection)
+  ((handle :initarg :handle)
+   (file :initarg :file
+         :type (or null string)
+         :documentation "Database file name.")
+   (types :allocation :class
+          :reader emacsql-types
+          :initform '((integer "INTEGER")
+                      (float "REAL")
+                      (object "TEXT")
+                      (nil nil)))
+  (:documentation
+   "A connection to a SQLite database using the `sqlite3-api' module.")))
+
+(cl-defun emacsql-sqlite3 (file &key debug)
+  (let ((connection (make-instance 'emacsql-sqlite3-connection :file file)))
+    (when debug
+      (emacsql-enable-debugging connection))
+    connection))
+
+(cl-defmethod initialize-instance :after
+  ((connection emacsql-sqlite3-connection) &rest _)
+  (oset connection handle
+        (sqlite3-open (if-let ((file (slot-value connection 'file)))
+                          (expand-file-name file)
+                        ":memory:")
+                      sqlite-open-readwrite
+                      sqlite-open-create))
+  (emacsql-register connection))
+
+(cl-defmethod emacsql-close ((connection emacsql-sqlite3-connection))
+  (sqlite3-close (oref connection handle)))
+
+(cl-defmethod emacsql ((connection emacsql-sqlite3-connection) sql &rest args)
+  (let (ret)
+    (sqlite3-exec (oref connection handle)
+                  (apply #'emacsql-compile connection sql args)
+                  (lambda (_ncols data _names)
+                    (push (mapcar (lambda (s)
+                                    (if (stringp s)
+                                        (car (read-from-string s))
+                                      s))
+                                  data)
+                          ret)))
+    (nreverse ret)))
+
+(provide 'emacsql-sqlite3)
+
+;;; emacsql-sqlite3.el ends here

--- a/emacsql.el
+++ b/emacsql.el
@@ -165,8 +165,10 @@ MESSAGE should not have a newline on the end."
 (cl-defgeneric emacsql-parse (connection)
   "Return the results of parsing the latest output or signal an error.")
 
-(defun emacsql-compile (connection sql &rest args)
-  "Compile s-expression SQL for CONNECTION into a string."
+(cl-defgeneric emacsql-compile (connection sql &rest args)
+  "Compile s-expression SQL for CONNECTION into a string.")
+
+(cl-defmethod emacsql-compile ((connection emacsql-connection) sql &rest args)
   (let* ((mask (when connection (emacsql-types connection)))
          (emacsql-type-map (or mask emacsql-type-map)))
     (concat (apply #'emacsql-format (emacsql-prepare sql) args) ";")))


### PR DESCRIPTION
This new back-end relies on [a module](https://github.com/pekingduck/emacs-sqlite3-api) instead of the custom executable used by `emacsql-sqlite.el`.

I have implemented this in the hope it would help with [the meaning of live #42](https://github.com/skeeto/emacsql/issues/42) and to some extend it does; it doesn't error when storing a string that contains a null character (instead if silently discards the text that follows, and then errors when trying to `read` the incomplete string again). The reason this works is that it uses `sqlite3_bind*()` to supply the parameters - that way SQLite does not try and fail to tokenize the value containing the null character.

Since this approach is not enough to fix the issue I was having (while changing more than needed to do so), I probably won't work on this for a while, and it should be considered a proof-of-concept. While it would be nice to complete this eventually, there is still quite a bit work left. For starters, `sqlite3` would have to be made available on Melpa (1) and the `sqlite3` errors would have to be converted to `emacsql` errors.

(1) I would welcome that even if this back-end never got finished, and I would be willing to lend a helping hand here.

/cc @pekingduck