### PR TITLE
Add precedence handling for "between" syntax

### DIFF
--- a/emacsql-compiler.el
+++ b/emacsql-compiler.el
@@ -360,7 +360,10 @@ Only use within `emacsql-with-params'!"
               ((<= >=)
                (cl-case (length args)
                  (2 (format format-string (recur 0) (recur 1)))
-                 (3 (format "%s BETWEEN %s AND %s"
+                 (3 (format (if (>= (or parent-precedence-value 0)
+                                    precedence-value)
+                                "(%s BETWEEN %s AND %s)"
+                              "%s BETWEEN %s AND %s")
                             (recur 1)
                             (recur (if (eq op '>=) 2 0))
                             (recur (if (eq op '>=) 0 2))))

--- a/tests/emacsql-compiler-tests.el
+++ b/tests/emacsql-compiler-tests.el
@@ -242,7 +242,9 @@
    ([:select (funcall length (|| (* x x) (* y y) (* z z)))] '()
     "SELECT length((x * x) || (y * y) || (z * z));")
    ([:select (and (+ (<= x y) 1) (>= y x))] '()
-    "SELECT (x <= y) + 1 AND y >= x;")))
+    "SELECT (x <= y) + 1 AND y >= x;")
+   ([:select (or (& (<= x (+ y 1) (- z)) 1) (>= x z y))] '()
+    "SELECT (y + 1 BETWEEN x AND -z) & 1 OR z BETWEEN y AND x;")))
 
 (provide 'emacsql-compiler-tests)
 


### PR DESCRIPTION
As mentioned in PR #47, this PR is for handling the precedence of the
"BETWEEN" operator and also includes a simple test.

I'm also taking the chance to ask you about this loop in the
operator format string expansion:
https://github.com/skeeto/emacsql/blob/a164ecd9d31dbd45a646244906ac077d5a331419/emacsql-compiler.el#L321

I'm not quite happy with it, but couldn't really come up with anything
better. Any ideas maybe?