### PR TITLE
Add some support for the ESCAPE operator

### DIFF
--- a/tests/emacsql-compiler-tests.el
+++ b/tests/emacsql-compiler-tests.el
@@ -181,7 +181,9 @@
     ([:where (= name 'foo)] '()
      "WHERE name = 'foo';")
     ([:where (= name '$s1)] '(qux)
-     "WHERE name = 'qux';")))
+     "WHERE name = 'qux';")
+    ([:where (like url (escape "%`%%" ?`))] '()
+     "WHERE url LIKE '\"%`%%\"' ESCAPE '`';")))
 
 (ert-deftest emacsql-expr ()
   (emacsql-tests-with-queries


### PR DESCRIPTION
Hi, this is my shot for at least partially fixing issue #10. I've
added special case handling for the `escape` operator to ensure that
the second operand is an Emacs character. Using backslash is still not
practically possible as the values that are matched are still printed,
but now other characters (which are not escaped by printing) can be
used safely. For example this works just fine now:

```elisp
[:select url
 :from [:select "http://example.com/%test" :as url] :as tmp
 :where (like url (escape "%`%%" ?`))]
```

As far as I recall backticks are not allowed in URLs, so this seems to
be a viable alternative for this exact use-case. You'll have to be
careful choosing your escape character, but that is already the case
when you use SQLite. This change allows you to use at least a subset
of what SQLite allows for.

Please let me know what you think!
