### PR TITLE
Handle read-only emacsql install diretory

### DIFF
--- a/emacsql-sqlite.el
+++ b/emacsql-sqlite.el
@@ -28,9 +28,8 @@
   "Directory where EmacSQL is installed.")
 
 (defvar emacsql-sqlite-executable-path
-  (if (memq system-type '(windows-nt cygwin ms-dos))
-      "sqlite/emacsql-sqlite.exe"
-    "sqlite/emacsql-sqlite")
+  (concat "sqlite/emacsql-sqlite-" emacsql-version
+          (when (memq system-type '(windows-nt cygwin ms-dos)) ".exe"))
   "Relative path to emacsql executable.")
 
 (defvar emacsql-sqlite-executable


### PR DESCRIPTION
Some systems will have set installs to read-only. This means that we
cannot compile emacsql-sqlite directly in that directory. Luckily, it
is very easy to make emacsql-sqlite compile to an arbitrary directory.
This patch uses ~/.emacs.d/sqlite/emacsql-sqlite as a backup when the
install directory is read only.