### PR TITLE
Add public domain statement to remaining files

### DIFF
--- a/emacsql-compiler.el
+++ b/emacsql-compiler.el
@@ -1,5 +1,7 @@
 ;;; emacsql-compile.el --- s-expression SQL compiler -*- lexical-binding: t; -*-
 
+;; This is free and unencumbered software released into the public domain.
+
 ;;; Code:
 
 (require 'cl-lib)

--- a/emacsql-pg.el
+++ b/emacsql-pg.el
@@ -1,5 +1,7 @@
 ;;; emacsql-pg.el --- back-end for PostgreSQL via pg -*- lexical-binding: t; -*-
 
+;; This is free and unencumbered software released into the public domain.
+
 ;;; Commentary:
 
 ;; Unlike emacsql-psql, this connection type uses Eric Marsden's pg.el

--- a/sqlite/emacsql.c
+++ b/sqlite/emacsql.c
@@ -1,3 +1,5 @@
+/* This is free and unencumbered software released into the public domain.  */
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/tests/emacsql-compiler-tests.el
+++ b/tests/emacsql-compiler-tests.el
@@ -1,5 +1,7 @@
 ;;; emacsql-tests.el --- tests for emacsql -*- lexical-binding: t; -*-
 
+;; This is free and unencumbered software released into the public domain.
+
 ;;; Code:
 
 (require 'ert)

--- a/tests/emacsql-external-tests.el
+++ b/tests/emacsql-external-tests.el
@@ -1,5 +1,7 @@
 ;;; emacsql-external-tests.el --- subprocess tests -*- lexical-binding: t; -*-
 
+;; This is free and unencumbered software released into the public domain.
+
 (require 'cl-lib)
 (require 'ert)
 (require 'emacsql)

--- a/tests/emacsql-tests.el
+++ b/tests/emacsql-tests.el
@@ -1,5 +1,7 @@
 ;;; emacsql-tests.el --- test suite for EmacSQL -*- lexical-binding: t; -*-
 
+;; This is free and unencumbered software released into the public domain.
+
 (require 'cl-lib)
 (require 'emacsql-compiler-tests)
 (require 'emacsql-external-tests)


### PR DESCRIPTION
Hi!

I am investigating if we could add this package to [NonGNU ELPA](http://elpa.nongnu.org/) (see link), a new Emacs Lisp package archive that will be enabled by default in Emacs 28. This means that users of that version or later will be able to install this package without any configuration: they can just run `M-x list-packages` and install it out of the box. We hope that this will improve Emacs and help bring new users to this package and others.

However, NonGNU ELPA has a requirement that all files to have a clear statement of its license and copyright status. I believe this patch would be sufficient to fulfill this requirement.

Please let me know if you have any questions about NonGNU ELPA.

Thanks!