### PR TITLE
Bump version to 3.1.0

### DIFF
--- a/emacsql-mysql.el
+++ b/emacsql-mysql.el
@@ -4,7 +4,7 @@
 
 ;; Author: Christopher Wellons <wellons@nullprogram.com>
 ;; URL: https://github.com/skeeto/emacsql
-;; Version: 1.0.0
+;; Version: 1.0.1
 ;; Package-Requires: ((emacs "25.1") (emacsql "2.0.0"))
 
 ;;; Commentary:

--- a/emacsql-psql.el
+++ b/emacsql-psql.el
@@ -4,7 +4,7 @@
 
 ;; Author: Christopher Wellons <wellons@nullprogram.com>
 ;; URL: https://github.com/skeeto/emacsql
-;; Version: 1.0.0
+;; Version: 1.0.1
 ;; Package-Requires: ((emacs "25.1") (emacsql "2.0.0"))
 
 ;;; Commentary:

--- a/emacsql-sqlite.el
+++ b/emacsql-sqlite.el
@@ -4,7 +4,7 @@
 
 ;; Author: Christopher Wellons <wellons@nullprogram.com>
 ;; URL: https://github.com/skeeto/emacsql
-;; Version: 1.0.0
+;; Version: 1.0.1
 ;; Package-Requires: ((emacs "25.1") (emacsql "2.0.0"))
 
 ;;; Commentary:

--- a/emacsql.el
+++ b/emacsql.el
@@ -4,7 +4,7 @@
 
 ;; Author: Christopher Wellons <wellons@nullprogram.com>
 ;; URL: https://github.com/skeeto/emacsql
-;; Version: 3.0.0
+;; Version: 3.1.0
 ;; Package-Requires: ((emacs "25.1"))
 
 ;;; Commentary:
@@ -69,7 +69,7 @@
   "The EmacSQL SQL database front-end."
   :group 'comm)
 
-(defconst emacsql-version "3.0.0")
+(defconst emacsql-version "3.1.0")
 
 (defvar emacsql-global-timeout 30
   "Maximum number of seconds to wait before bailing out on a SQL command.


### PR DESCRIPTION
Continuing work on adding this package NonGNU ELPA, I noticed that it's been over three years since the last release. I therefore suggest making a new one.

The main difference between NonGNU ELPA and MELPA is that only stable versions of packages are released. A new release will be made automatically when you bump the ";;; Version: NNN" commentary header in the main file of this repository. This is similar to MELPA Stable, but we do not care about the git tag; only the commentary header. In the future, you can bump the package version in that header (thereby releasing a new version) when you think it makes sense and at your convenience.