### PR TITLE
Make Emacs 29's byte-compiler happy

### DIFF
--- a/emacsql.el
+++ b/emacsql.el
@@ -136,7 +136,7 @@ MESSAGE should not have a newline on the end."
 
 ;;; Sending and receiving
 
-(cl-defgeneric emacsql-send-message ((connection emacsql-connection) message)
+(cl-defgeneric emacsql-send-message (connection message)
   "Send MESSAGE to CONNECTION.")
 
 (cl-defmethod emacsql-send-message :before
@@ -171,7 +171,7 @@ MESSAGE should not have a newline on the end."
          (emacsql-type-map (or mask emacsql-type-map)))
     (concat (apply #'emacsql-format (emacsql-prepare sql) args) ";")))
 
-(cl-defgeneric emacsql ((connection emacsql-connection) sql &rest args)
+(cl-defgeneric emacsql (connection sql &rest args)
   "Send SQL s-expression to CONNECTION and return the results.")
 
 (cl-defmethod emacsql ((connection emacsql-connection) sql &rest args)

--- a/emacsql.el
+++ b/emacsql.el
@@ -171,8 +171,10 @@ MESSAGE should not have a newline on the end."
          (emacsql-type-map (or mask emacsql-type-map)))
     (concat (apply #'emacsql-format (emacsql-prepare sql) args) ";")))
 
+(cl-defgeneric emacsql ((connection emacsql-connection) sql &rest args)
+  "Send SQL s-expression to CONNECTION and return the results.")
+
 (cl-defmethod emacsql ((connection emacsql-connection) sql &rest args)
-  "Send SQL s-expression to CONNECTION and return the results."
   (let ((sql-string (apply #'emacsql-compile connection sql args)))
     (emacsql-clear connection)
     (emacsql-send-message connection sql-string)


### PR DESCRIPTION
```
emacsql.el: Warning: Non-symbol arguments to cl-defgeneric: (connection emacsql-connection)
lib/emacsql/emacsql.el:139:39: Warning: Non-symbol arguments to cl-defgeneric: (connection emacsql-connection)
```