### PR TITLE
Fix intermittent "wrong type argument: sqlitep nil"

### DIFF
--- a/emacsql-sqlite-builtin.el
+++ b/emacsql-sqlite-builtin.el
@@ -49,8 +49,9 @@ buffer.  This is for debugging purposes."
   (and (oref connection handle) t))
 
 (cl-defmethod emacsql-close ((connection emacsql-sqlite-builtin-connection))
-  (sqlite-close (oref connection handle))
-  (oset connection handle nil))
+  (when (oref connection handle)
+    (sqlite-close (oref connection handle))
+    (oset connection handle nil)))
 
 (cl-defmethod emacsql-send-message
   ((connection emacsql-sqlite-builtin-connection) message)

--- a/emacsql-sqlite-module.el
+++ b/emacsql-sqlite-module.el
@@ -55,8 +55,9 @@ buffer.  This is for debugging purposes."
   (and (oref connection handle) t))
 
 (cl-defmethod emacsql-close ((connection emacsql-sqlite-module-connection))
-  (sqlite3-close (oref connection handle))
-  (oset connection handle nil))
+  (when (oref connection handle)
+    (sqlite3-close (oref connection handle))
+    (oset connection handle nil)))
 
 (cl-defmethod emacsql-send-message
   ((connection emacsql-sqlite-module-connection) message)


### PR DESCRIPTION
This patches the `emacsql-close` method for sqlite-builtin and sqlite-module to check `(oref connection handle)` first. 

As a result, you can call `emacsql-close` any number of times without error.  This is similar to the methods for the other database types, which contain a similar check.  (psql and mysql check `process-live-p`, and pg just does `ignore-errors`)

It prevents the recurring message "`wrong type argument: sqlitep nil`" that at least some users see while using org-roam. Credit for finding the problem https://github.com/org-roam/org-roam/issues/2532#issuecomment-3457190149

### Digression

I've looked in the org-roam codebase for where it might call `emacsql-close` incorrectly, but I cannot find it.  The only place that it directly calls `emacsql-close` in regular use is the function `org-roam-db--close`, which does already check `emacsql-live-p`: https://github.com/org-roam/org-roam/blob/6abb3bdc5a4491bbfa01d1f10d9ddb4fd4626887/org-roam-db.el#L239-L246

So I'm not sure if this may indicate a problem in emacsql... or perhaps that the issue comes from user code or extensions that also call `emacsql-close`.